### PR TITLE
Even more strict builds

### DIFF
--- a/Kernel/kernel.c
+++ b/Kernel/kernel.c
@@ -17,11 +17,11 @@ extern uint8_t endOfKernel;
 
 static const uint64_t PageSize = 0x4000;
 
-static const void * shellModuleAddress = (void*)0x400000;
+typedef int (*EntryPoint)(unsigned int pcount, char * pgname[], void * pgptrs[]);
+
+static const EntryPoint shellModuleAddress = (EntryPoint) 0x400000;
 
 unsigned int timer = 0;
-
-typedef int (*EntryPoint)(unsigned int pcount, char * pgname[], void * pgptrs[]);
 
 void clearBSS(void * bssAddress, uint64_t bssSize)
 {
@@ -43,7 +43,7 @@ void * initializeKernelBinary()
 	 * IT BREAKS, LIKE, *REALLY* BAD.
 	 */
 	void * moduleAddresses[] = {
-	    (void *) shellModuleAddress
+	    (void *)(EntryPoint *) &shellModuleAddress
 	};
 
 	loadModules(&endOfKernelBinary, moduleAddresses);
@@ -81,7 +81,7 @@ int main()
 	kbrd_install();
 	vid_clr();
 
-    ((EntryPoint)shellModuleAddress)(0, (char **) 0, (void *) 0);
+    (shellModuleAddress)(0, (char **) 0, (void *) 0);
 
     syscall_halt();
 	return 0;

--- a/Kernel/mmu.c
+++ b/Kernel/mmu.c
@@ -1,1 +1,4 @@
 #include <mmu.h>
+#include <stddef.h>
+void * mmu_page_alloc(size_t size);
+void * mmu_page_free(void * ptr);

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -8,8 +8,8 @@ AR?=ar
 ASM?=nasm
 
 
-CFLAGS=-ffreestanding -fno-asynchronous-unwind-tables -fno-builtin-free -fno-builtin-malloc -fno-builtin-realloc -fno-common -fno-exceptions -m64 -mno-mmx -mno-red-zone -mno-sse -mno-sse2 -nostdlib
-STDFLAGS=-std=c99 -Wall -Werror -Wno-multichar
+CFLAGS=-ffreestanding -fno-asynchronous-unwind-tables -fno-builtin-free -fno-builtin-malloc -fno-builtin-realloc -fno-common -fno-exceptions -m64 -mno-mmx -mno-red-zone -mno-sse -mno-sse2 -nostdlib -pipe
+STDFLAGS=-std=c99 -Wall -Werror -Wno-multichar -pedantic -pedantic-errors
 GCCFLAGS=${CFLAGS} ${STDFLAGS}
 ARFLAGS=rvs
 ASMFLAGS=-felf64


### PR DESCRIPTION
Use the `-pedantic` and `-pedantic-errors` flags to make things really strict. This should help a lot guarding against undefined behaviour and the likes.
