### PR TITLE
Re-label some syscall numbers

### DIFF
--- a/Kernel/i64int.asm
+++ b/Kernel/i64int.asm
@@ -7,7 +7,8 @@ GLOBAL idt_pic_master_mask
 GLOBAL idt_pic_slave_mask
 GLOBAL idt_pic_master_set_map
 GLOBAL idt_pic_slave_set_map
-GLOBAL _irq_sys_handler
+GLOBAL _int_sys_handler
+GLOBAL _int_mem_handler
 
 EXTERN irq_handler
 EXTERN mem_handler
@@ -127,7 +128,7 @@ idt_pic_slave_set_map:
 
 
 ;Int 80h
-_irq_sys_handler:
+_int_sys_handler:
 	cli
     push    RBP
     PUSHALL
@@ -137,8 +138,7 @@ _irq_sys_handler:
 	sti
 	iretq
 
-GLOBAL _int_eh_handler
-_int_eh_handler:
+_int_mem_handler:
     cli
     push rax
     push rdi

--- a/Kernel/include/syscalls.h
+++ b/Kernel/include/syscalls.h
@@ -4,6 +4,27 @@
 #include <interrupts.h>
 #include <stdint.h>
 
+/* Syscall numbers taken from http://blog.rchapman.org/post/36801038863/linux-system-call-table-for-x86-64 */
+
+enum SyscallNumber {
+	SYSCALL_WRITE 	= 0,
+	SYSCALL_READ 	= 1,
+	SYSCALL_OPEN 	= 2,
+	SYSCALL_CLOSE 	= 3,
+	SYSCALL_MMAP	= 9,
+	SYSCALL_MUNMAP	= 11,
+	SYSCALL_IOCTL 	= 16,
+	SYSCALL_PIPE 	= 22,
+	SYSCALL_PAUSE 	= 34,
+	SYSCALL_GETPID 	= 39,
+	SYSCALL_BEEP 	= 42,
+	SYSCALL_HALT 	= 48,
+	SYSCALL_FORK 	= 57,
+	SYSCALL_EXECV 	= 59,
+	SYSCALL_EXIT 	= 60,
+	SYSCALL_SETTIME = 227,
+	SYSCALL_GETTIME = 228
+};
 
 int syscall_write(unsigned int fd, char *str, unsigned int size);
 int syscall_read(unsigned int fd, char * buf, unsigned int size);

--- a/Kernel/interrupts.c
+++ b/Kernel/interrupts.c
@@ -16,6 +16,8 @@
 
 #define IDTE_HW			(IDTE_PRESENT | IDTE_DPL_HW | IDTE_I_GATE)
 #define IDTE_SW			(IDTE_PRESENT | IDTE_DPL_SW | IDTE_I_GATE)
+#define INT_SYS 		0x80
+#define INT_MEM			0x0E
 
 
 /* The following structs are packed to reflect the arch registers. 
@@ -54,8 +56,8 @@ extern void idt_pic_master_set_map(char);
 extern void idt_pic_slave_mask(char);
 extern void idt_pic_master_mask(char);
 
-extern void _int_eh_handler(void);
-extern void _irq_sys_handler(void);
+extern void _int_mem_handler(void);
+extern void _int_sys_handler(void);
 
 extern void _irq_20h_handler(void);
 extern void _irq_21h_handler(void);
@@ -160,8 +162,8 @@ void install_interrupts(void)
 	table = (struct IDT_Entry *) idtr->offset;
 
 	/* override int80h entry */
-	install_IDT_entry(table, 0x80, 			&_irq_sys_handler, IDTE_SW);
-	install_IDT_entry(table, 0xe, 			&_int_eh_handler,  IDTE_SW);
+	install_IDT_entry(table, INT_SYS, 		&_int_sys_handler, IDTE_SW);
+	install_IDT_entry(table, INT_MEM, 		&_int_mem_handler, IDTE_SW);
 
 	/* override Master HW ints with our own */
 	install_IDT_entry(table, INT_PIT, 		&_irq_20h_handler, IDTE_HW);

--- a/Kernel/syscalls.c
+++ b/Kernel/syscalls.c
@@ -120,40 +120,40 @@ uint64_t int80h(uint64_t sysno, uint64_t RDI, uint64_t RSI, uint64_t RDX, uint64
 {
 	int exitno = 0;
 	switch (sysno) {
-		case 0: /* sys_write fd buf size */
+		case SYSCALL_WRITE: /* sys_write fd buf size */
 		exitno = syscall_write((unsigned int) RDI, (char *) RSI, (unsigned int) RDX);
 		break;
 
-		case 1: /* sys_read fd buf size */
+		case SYSCALL_READ: /* sys_read fd buf size */
 		exitno = syscall_read((unsigned int) RDI, (char *) RSI, (unsigned int) RDX);
 		break;
 
-		case 6:
+		case SYSCALL_IOCTL:
 		exitno = syscall_ioctl((unsigned int) RDI, (unsigned long) RSI, (void *) RDX);
 		break;
 
-		case 34: /* sys_pause */
+		case SYSCALL_PAUSE: /* sys_pause */
 		syscall_pause();
 		break;
 
-		case 48: /* sys_shutdown */
+		case SYSCALL_HALT: /* sys_shutdown */
 		syscall_halt();
 		break;
 
-		case 42: /* sys_beep */
+		case SYSCALL_BEEP: /* sys_beep */
 		beep();
 		break;
 
-		case 200:
+		case SYSCALL_GETTIME:
 		syscall_get_time((struct rtc_time *) RDI);
 		break;
 
-		case 201:
+		case SYSCALL_SETTIME:
 		syscall_set_time((struct rtc_time *) RDI);
 		break;
 
 		default:
-		return 0;
+		return -1;
 	}
 	return exitno;
 }

--- a/Userland/libc/syscalls.asm
+++ b/Userland/libc/syscalls.asm
@@ -48,10 +48,25 @@ GLOBAL %1
 
 _int80h	write, 0
 _int80h read, 1
+_int80h open, 2
+_int80h close, 3
+
+_int80h mmap, 9
+_int80h munmap, 11
+
 _int80h ioctl, 16
+_int80h pipe, 22
+
 _int80h pause, 34
+_int80h getpid, 39
+_int80h beep, 42
+
 _int80h halt, 48
 _int80h shutdown, 48
-_int80h beep, 42
+
+_int80h fork, 57
+_int80h execv, 59
+_int80h exit, 60
+
 _int80h gettime, 228
 _int80h settime, 227

--- a/Userland/libc/syscalls.asm
+++ b/Userland/libc/syscalls.asm
@@ -48,10 +48,10 @@ GLOBAL %1
 
 _int80h	write, 0
 _int80h read, 1
-_int80h ioctl, 6
+_int80h ioctl, 16
 _int80h pause, 34
 _int80h halt, 48
 _int80h shutdown, 48
 _int80h beep, 42
-_int80h gettime, 200
-_int80h settime, 201
+_int80h gettime, 228
+_int80h settime, 227


### PR DESCRIPTION
This will make the syscall convention match the Linux numbers.
